### PR TITLE
Redesign site as AI builder hub

### DIFF
--- a/ai-lab.html
+++ b/ai-lab.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Lab | Yogeash Nehra</title>
+    <meta name="description" content="A collection of AI tools, experiments, and builds by Yogeash Nehra. Use them, break them, tell me what's broken.">
+    <link rel="icon" href="ynfavicon.ico">
+    <link rel="stylesheet" href="styles.css">
+    <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
+    <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+    <div id="navbar-placeholder"></div>
+    <script src="navbar.js"></script>
+
+    <!-- Hero -->
+    <header class="hero hero-ailab">
+        <div class="container">
+            <span class="hero-label">Experiments · Tools · Builds</span>
+            <h1>AI Lab</h1>
+            <p class="hero-tagline">A collection of AI tools and experiments I'm building.<br>Use them, break them, tell me what's broken.</p>
+        </div>
+    </header>
+
+    <!-- Live Tools -->
+    <section>
+        <div class="container">
+            <div class="section-header">
+                <h2>Live Tools</h2>
+            </div>
+            <div class="ailab-grid">
+                <div class="ailab-card ailab-card--featured">
+                    <span class="tag tag--live">Live</span>
+                    <h3>Idea Lab</h3>
+                    <p>Describe any project idea and get back a feasibility score (1–10), a phased execution plan with tech stack recommendation, and a downloadable repo scaffold ready for AI agents to build from.</p>
+                    <p>Supports Claude (Anthropic) and GPT-4o (OpenAI) — bring your own API key, nothing is stored server-side.</p>
+                    <a href="idea" class="btn">Open Idea Lab →</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Experiments & Builds -->
+    <section>
+        <div class="container">
+            <div class="section-header">
+                <h2>Experiments &amp; Builds</h2>
+            </div>
+            <div class="ailab-grid">
+                <div class="ailab-card">
+                    <span class="tag tag--hackathon">AI Hackathon 2024</span>
+                    <h3>EduEqual</h3>
+                    <p>AI-powered platform that personalises learning content for underserved students. Conceived, built, and presented in 24 hours at the 2024 AI Hackathon.</p>
+                    <a href="projects" class="btn">View on Projects →</a>
+                </div>
+                <div class="ailab-card">
+                    <span class="tag tag--capstone">Capstone Project</span>
+                    <h3>PiLot Autonomous Rover</h3>
+                    <p>Autonomous farm rover with GPS navigation, obstacle avoidance, live video streaming, and sensor telemetry. Tested on real farmland — not just a classroom demo.</p>
+                    <a href="capstone" class="btn">View Capstone →</a>
+                </div>
+                <div class="ailab-card">
+                    <span class="tag tag--experiment">Experiment</span>
+                    <h3>AWS IoT Dashboard</h3>
+                    <p>Live telemetry and video streaming dashboard for IoT devices built on AWS. Powers the real-time data pipeline for the PiLot Rover.</p>
+                    <a href="projects" class="btn">View on Projects →</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- More Coming -->
+    <section class="section-about">
+        <div class="container container--narrow">
+            <h2>More incoming</h2>
+            <p>I'm constantly shipping new tools and running experiments. Follow on YouTube and LinkedIn to see what's in progress before it lands here.</p>
+            <div class="about-links">
+                <a href="https://www.linkedin.com/in/yogeash-nehra/" target="_blank" class="btn btn-white-on-dark">LinkedIn</a>
+                <a href="https://youtube.com/@yogeash-nehra" target="_blank" class="btn btn-outline-on-dark">YouTube</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <div class="footer-inner">
+                <span class="footer-name">Yogeash Nehra</span>
+                <div class="social-links">
+                    <a href="https://www.linkedin.com/in/yogeash-nehra/" target="_blank">LinkedIn</a>
+                    <a href="mailto:info@yogeashnehra.com">Email</a>
+                    <a href="https://youtube.com/@yogeash-nehra" target="_blank">YouTube</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/capstone.html
+++ b/capstone.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Capstone | Yogeash Nehra</title>
     <link rel="stylesheet" href="styles.css">
+    <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
     <!-- Navigation Bar -->

--- a/idea.html
+++ b/idea.html
@@ -8,6 +8,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,700;1,9..40,300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
+    <script defer src="/_vercel/insights/script.js"></script>
     <style>
         /* ── Idea Lab overrides & extensions ── */
         :root {

--- a/index.html
+++ b/index.html
@@ -3,84 +3,95 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Yogeash Nehra | Portfolio</title>
+    <title>Yogeash Nehra | AI Builder</title>
+    <meta name="description" content="Yogeash Nehra — AI builder and full-stack developer. Tools, experiments, and projects shipped with AI.">
+    <link rel="icon" href="ynfavicon.ico">
     <link rel="stylesheet" href="styles.css">
+    <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
-    <!-- Navigation Bar -->
     <div id="navbar-placeholder"></div>
     <script src="navbar.js"></script>
 
-    <!-- Hero Section -->
-    <header class="hero">
+    <!-- Hero -->
+    <header class="hero hero-full">
         <div class="container">
+            <span class="hero-label">AI Builder · Full-Stack Developer</span>
             <h1>Yogeash Nehra</h1>
-            <p class="hero-tagline">Delivering innovative IT solutions in full-stack, cloud, and automation.</p>
+            <p class="hero-tagline">Building AI-powered tools that actually ship.<br>From concept to execution — fast.</p>
+            <div class="hero-ctas">
+                <a href="ai-lab" class="btn btn-white">Explore AI Lab</a>
+                <a href="projects" class="btn btn-outline">All Projects</a>
+            </div>
         </div>
     </header>
 
-    <!-- About Section -->
-    <section>
+    <!-- Featured AI Work -->
+    <section class="section-featured">
         <div class="container">
-            <h2>About Me</h2>
-            <div class="about-grid">
-                <div class="about-item">
-                    <h3>My Background</h3>
-                    <p>Bachelor of Computing Systems graduate with a passion for full-stack development, cloud technologies, and IT innovation.</p>
-                    <p>Experienced in delivering practical solutions through both academic and industry projects.</p>
-                </div>
-                <div class="about-item">
-                    <h3>My Skills</h3>
-                    <p><strong>Frontend:</strong> React, HTML, CSS, JavaScript</p>
-                    <p><strong>Backend:</strong> C#, .NET, Django, Python</p>
-                    <p><strong>Cloud &amp; Tools:</strong> AWS, Azure</p>
-                    <p>Strong in database management, API integration, and scalable system design.</p>
-                </div>
-                <div class="about-item">
-                    <h3>My Experience</h3>
-                    <p>Built and managed client websites, streamlined IT infrastructure for small businesses, contributed to cloud-based applications, and developed interactive games.</p>
-                    <p>Hands-on experience from real-world projects and hackathons.</p>
-                </div>
+            <div class="section-header">
+                <h2>Featured AI Work</h2>
+                <a href="ai-lab" class="section-link">View all →</a>
             </div>
-        </div>
-    </section>
-
-    <!-- Projects Preview Section -->
-    <section>
-        <div class="container">
-            <h2>Featured Projects</h2>
-            <div class="home-projects-grid">
-                <div class="home-project-item">
-                    <h3>Smart Agriculture Rover</h3>
-                    <p>Autonomous rover for real-time farm monitoring and automation.</p>
-                    <a href="capstone" class="project-link">View Capstone</a>
-                </div>
-                <div class="home-project-item">
-                    <h3>Cloud Dashboard</h3>
-                    <p>Live telemetry and video streaming for IoT devices, built with AWS and React.</p>
-                    <a href="projects" class="project-link">View Projects</a>
-                </div>
-                <div class="home-project-item">
+            <div class="featured-grid">
+                <div class="featured-card">
+                    <span class="tag tag--live">Live Tool</span>
                     <h3>Idea Lab</h3>
-                    <p>Describe an idea, get a feasibility score, phased execution plan, and a downloadable repo scaffold — ready for Cursor or VS Code agent to build.</p>
-                    <a href="idea" class="project-link">Try Idea Lab</a>
+                    <p>Drop an idea, get a feasibility score, phased execution plan, and a downloadable repo scaffold — ready for Cursor or VS Code agent to build from.</p>
+                    <a href="idea" class="btn">Try it →</a>
+                </div>
+                <div class="featured-card">
+                    <span class="tag tag--hackathon">AI Hackathon 2024</span>
+                    <h3>EduEqual</h3>
+                    <p>AI-powered education platform that personalises learning content for underserved students. Built and demoed in 24 hours.</p>
+                    <a href="projects" class="btn">View Project →</a>
+                </div>
+                <div class="featured-card">
+                    <span class="tag tag--capstone">Capstone</span>
+                    <h3>PiLot Autonomous Rover</h3>
+                    <p>Real-world autonomous rover for farm monitoring — live video, GPS navigation, sensor data, and obstacle avoidance tested on actual farmland.</p>
+                    <a href="capstone" class="btn">View Build →</a>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- Contact Section -->
+    <!-- About -->
+    <section class="section-about">
+        <div class="container container--narrow">
+            <h2>About</h2>
+            <p>Computing Systems graduate focused on building and shipping AI-powered products. I work across the full stack — React frontends, Python backends, AWS infrastructure — but the through-line is always the same: build something real and useful.</p>
+            <p>This site is where I share the tools, experiments, and projects I'm building with AI. If something looks useful, use it.</p>
+            <div class="skill-tags">
+                <span class="skill-tag">React</span>
+                <span class="skill-tag">Python</span>
+                <span class="skill-tag">Claude API</span>
+                <span class="skill-tag">OpenAI</span>
+                <span class="skill-tag">AWS</span>
+                <span class="skill-tag">Azure</span>
+                <span class="skill-tag">Django</span>
+                <span class="skill-tag">C# / .NET</span>
+            </div>
+            <div class="about-links">
+                <a href="Yogeash_Nehra_Resume.pdf" target="_blank" class="btn btn-white-on-dark">Resume ↓</a>
+                <a href="projects" class="btn btn-outline-on-dark">All Projects</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
     <footer>
         <div class="container">
-            <h2>Connect with Me</h2>
-            <div class="social-links">
-                <a href="https://www.linkedin.com/in/yogeash-nehra/" target="_blank">LinkedIn</a>
-                <a href="mailto:info@yogeashnehra.com" target="_blank">Email</a>
-                <a href="https://youtube.com" target="_blank">YouTube</a>
+            <div class="footer-inner">
+                <span class="footer-name">Yogeash Nehra</span>
+                <div class="social-links">
+                    <a href="https://www.linkedin.com/in/yogeash-nehra/" target="_blank">LinkedIn</a>
+                    <a href="mailto:info@yogeashnehra.com">Email</a>
+                    <a href="https://youtube.com/@yogeash-nehra" target="_blank">YouTube</a>
+                </div>
             </div>
         </div>
     </footer>
-
-
 </body>
 </html>

--- a/navbar.js
+++ b/navbar.js
@@ -11,9 +11,9 @@
     </a>
     <ul class="nav-links">
       <li><a href="index.html"    class="nav-item" data-page="index">Home</a></li>
+      <li><a href="ai-lab"        class="nav-item" data-page="ai-lab">AI Lab</a></li>
       <li><a href="projects"      class="nav-item" data-page="projects">Projects</a></li>
       <li><a href="capstone"      class="nav-item" data-page="capstone">Capstone</a></li>
-      <li><a href="idea"          class="nav-item" data-page="idea">Idea Lab</a></li>
       <li><a href="https://www.linkedin.com/in/yogeash-nehra/" class="nav-item">Contact</a></li>
     </ul>
     <div class="hamburger" id="nav-toggle" aria-label="Open navigation" tabindex="0">

--- a/projects.html
+++ b/projects.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Projects | Yogeash Nehra</title>
     <link rel="stylesheet" href="styles.css">
+    <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
     <!-- Navigation Bar -->

--- a/styles.css
+++ b/styles.css
@@ -378,3 +378,373 @@ footer {
 body, html {
   overflow-x: hidden !important;
 }
+
+/* ====== HERO FULL (homepage) ====== */
+.hero-full {
+  min-height: 85vh;
+  flex-direction: column;
+  padding: 4rem 1rem 3rem;
+  background-image: radial-gradient(circle, #2a2a2a 1px, transparent 1px);
+  background-size: 30px 30px;
+}
+
+.hero-full h1 {
+  font-size: 4.5rem;
+  letter-spacing: -2px;
+  line-height: 1.05;
+}
+
+.hero-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #777;
+  border: 1px solid #333;
+  padding: 0.35rem 0.9rem;
+  border-radius: 20px;
+  display: inline-block;
+  margin-bottom: 1.8rem;
+}
+
+.hero-ctas {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 2.2rem;
+}
+
+.btn-white {
+  background: #fff;
+  color: #000;
+  border: 1.5px solid #fff;
+}
+
+.btn-white:hover {
+  background: transparent;
+  color: #fff;
+  border-color: #fff;
+  transform: translateY(-2px) scale(1.03);
+}
+
+.btn-outline {
+  background: transparent;
+  color: #ccc;
+  border: 1.5px solid #444;
+}
+
+.btn-outline:hover {
+  background: #fff;
+  color: #000;
+  border-color: #fff;
+  transform: translateY(-2px) scale(1.03);
+}
+
+/* Buttons on dark section backgrounds */
+.btn-white-on-dark {
+  display: inline-block;
+  padding: 0.8rem 1.5rem;
+  border-radius: 24px;
+  font-weight: bold;
+  font-size: 1rem;
+  background: #fff;
+  color: #000;
+  border: 1.5px solid #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+}
+
+.btn-white-on-dark:hover {
+  background: transparent;
+  color: #fff;
+  transform: translateY(-2px) scale(1.03);
+}
+
+.btn-outline-on-dark {
+  display: inline-block;
+  padding: 0.8rem 1.5rem;
+  border-radius: 24px;
+  font-weight: bold;
+  font-size: 1rem;
+  background: transparent;
+  color: #aaa;
+  border: 1.5px solid #444;
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+}
+
+.btn-outline-on-dark:hover {
+  background: #fff;
+  color: #000;
+  border-color: #fff;
+  transform: translateY(-2px) scale(1.03);
+}
+
+/* ====== SECTION HEADER ====== */
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.section-header h2 {
+  text-align: left;
+  margin-bottom: 0;
+}
+
+.section-link {
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: #888;
+  transition: color 0.2s;
+  white-space: nowrap;
+}
+
+.section-link:hover {
+  color: #000;
+}
+
+/* ====== FEATURED GRID ====== */
+section.section-featured {
+  padding: 3rem 0;
+}
+
+.featured-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.featured-card {
+  border: 1.5px solid #e0e0e0;
+  border-radius: 16px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  background: #fff;
+  transition: border-color 0.2s, transform 0.25s, box-shadow 0.25s;
+}
+
+.featured-card:hover {
+  border-color: #111;
+  transform: translateY(-5px);
+  box-shadow: 0 16px 40px rgba(0,0,0,0.1);
+}
+
+.featured-card h3 {
+  text-align: left;
+  font-size: 1.3rem;
+  margin-bottom: 0;
+  line-height: 1.3;
+}
+
+.featured-card p {
+  margin-bottom: 0;
+  flex: 1;
+  font-size: 0.97rem;
+  color: #444;
+  line-height: 1.65;
+}
+
+.featured-card .btn {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+/* ====== TAGS ====== */
+.tag {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.7rem;
+  border-radius: 20px;
+  width: fit-content;
+  line-height: 1.4;
+}
+
+.tag--live {
+  background: #000;
+  color: #fff;
+}
+
+.tag--hackathon {
+  border: 1.5px solid #222;
+  color: #222;
+  background: transparent;
+}
+
+.tag--capstone {
+  background: #efefef;
+  color: #444;
+}
+
+.tag--experiment {
+  background: #e8e8e8;
+  color: #555;
+}
+
+.tag--coming {
+  border: 1.5px solid #ccc;
+  color: #aaa;
+  background: transparent;
+}
+
+/* ====== ABOUT SECTION (dark) ====== */
+section.section-about {
+  background: #000 !important;
+  border-bottom: none;
+  padding: 3.5rem 0;
+}
+
+section.section-about h2 {
+  color: #fff;
+  text-align: left;
+}
+
+section.section-about p {
+  color: #aaa;
+  max-width: 680px;
+}
+
+.container--narrow {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 1.2rem;
+}
+
+/* ====== SKILL TAGS ====== */
+.skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1.8rem;
+}
+
+.skill-tag {
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid #333;
+  border-radius: 20px;
+  color: #888;
+}
+
+.about-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+/* ====== FOOTER ====== */
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-name {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #111;
+}
+
+/* ====== AI LAB HERO ====== */
+.hero-ailab {
+  min-height: 320px;
+  background: #000;
+  background-image: radial-gradient(circle, #222 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+/* ====== AI LAB GRID ====== */
+.ailab-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 0;
+}
+
+.ailab-card {
+  border: 1.5px solid #e0e0e0;
+  border-radius: 16px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #fff;
+  transition: border-color 0.2s, transform 0.25s, box-shadow 0.25s;
+}
+
+.ailab-card:hover {
+  border-color: #111;
+  transform: translateY(-5px);
+  box-shadow: 0 16px 40px rgba(0,0,0,0.1);
+}
+
+.ailab-card--featured {
+  grid-column: 1 / -1;
+  max-width: 620px;
+}
+
+.ailab-card h3 {
+  text-align: left;
+  font-size: 1.25rem;
+  margin-bottom: 0;
+}
+
+.ailab-card p {
+  margin-bottom: 0;
+  font-size: 0.97rem;
+  color: #444;
+  line-height: 1.65;
+}
+
+.ailab-card .btn {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+/* ====== RESPONSIVE ADDITIONS ====== */
+@media (max-width: 900px) {
+  .featured-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .ailab-card--featured {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 700px) {
+  .hero-full {
+    min-height: 70vh;
+  }
+  .hero-full h1 {
+    font-size: 2.8rem;
+    letter-spacing: -1px;
+  }
+  .featured-grid {
+    grid-template-columns: 1fr;
+  }
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .footer-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .about-links {
+    flex-direction: column;
+  }
+  .ailab-card--featured {
+    grid-column: auto;
+  }
+}


### PR DESCRIPTION
- Rewrites homepage with full-height hero, AI-first positioning, and featured work grid replacing the old 3-column CV layout
- Adds new AI Lab hub page (ai-lab.html) as a central place to surface all AI tools and experiments
- Adds AI Lab to the navbar and removes standalone Idea Lab nav item
- Extends styles.css with editorial components: dot-grid hero, B&W tag system, dark about section, skill tags — no new colours added
- Adds Vercel Web Analytics script to all five HTML pages